### PR TITLE
Rework event to be instanced

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+.idea/
+*.iml

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cavalcade
 *Cavalcade* is a **lightweight, asynchronous event library for Python**. 
-The main method for adding *events* is primarily via function decorators, 
+The main method for adding *events* is primarily via the event_factory function decorators, 
 although using Event objects is also perfectly legal.
 
 Events are managed by an *event manager* that runs in the background, and as 
@@ -9,7 +9,7 @@ events are called or created, they are added to a queue to be processed.
 ## Features
  * Support for **synchronous and asynchronous events**
  * A builtin **event manager** for queuing and processing events that runs in the background.
- * Support for **decorating functions/methods** as events
+ * Support for **decorating functions/methods** as event_factories
  * Support for **explicit event classes**
  * Support for manager **singletons**
  * Support for **callbacks** on completion of event
@@ -36,11 +36,17 @@ manager.stop()
   directly as it's not a *singleton*, The *DefaultManager* is the preferred
   reference implementation of this class. This class's purpose is to be subclassed. Also
   `cavalcade.managers.Manager`
+  * **`cavalcade.event_factory`:** The event_factory decorator, to be used when decorating
+  functions or methods. Also `cavalcade.decorators.event_factory`.
+  * **`cavalcade.EventFactory`:** The standard interface for defining events via decoration. 
+  Using the event decorator as above returns an object of this type. When an instance of this
+  class is called, it returns and schedules an Event instance. Also `cavalcade.events.EventFactory`.
   * **`cavalcade.event`:** The event decorator, to be used when decorating
   functions or methods. Also `cavalcade.decorators.event`.
   * **`cavalcade.Event`:** The base event object. Using the event decorator as
   above returns an object of this type. You can also subclass or instantiate
   this class directly. Also `cavalcade.events.Event`.
+
 
 # Examples
 
@@ -93,7 +99,7 @@ import cavalcade
 manager = cavalcade.DefaultManager()
 manager.start()
 
-@cavalcade.event()
+@cavalcade.event_factory()
 def event_print(string):
     print(string)
 
@@ -107,7 +113,7 @@ event_print('Hello World')
 import cavalcade
 import asyncio
 
-@cavalcade.event(name='Delayed_Print')
+@cavalcade.event_factory(name='Delayed_Print')
 async def delayed_print(string, delay):
     await asyncio.sleep(delay)
     print(string)
@@ -121,12 +127,12 @@ import asyncio
 # I'm going to use another event as my callback, which is good practice
 # That being said, there is no technical restriction to use an event
 
-@cavalcade.event(name='Done')
+@cavalcade.event_factory(name='Done')
 def done(event: cavalcade.Event):
     print(f'Event {event.name} Done')
 
 
-@cavalcade.event(name='Delayed_Print', callback=lambda: done(delayed_print))
+@cavalcade.event_factory(name='Delayed_Print', callback=lambda: done(delayed_print))
 async def delayed_print(string: str, delay: int):
     await asyncio.sleep(delay)
     print(string)
@@ -139,7 +145,7 @@ import cavalcade
 cavalcade.DefaultManager().start()
 
 
-@cavalcade.event(name='get_words')
+@cavalcade.event_factory(name='get_words')
 def get_words(sentence):
     return sentence.split(' ')
 

--- a/cavalcade/__init__.py
+++ b/cavalcade/__init__.py
@@ -1,7 +1,6 @@
 from . import events
 from . import managers
-from . import decorators
 
 from .events import Event
 from .managers import Manager, DefaultManager, Singleton
-from .decorators import event
+from .decorators import event, event_factory

--- a/cavalcade/decorators.py
+++ b/cavalcade/decorators.py
@@ -1,8 +1,15 @@
-from .events import Event
+from .events import Event, EventFactory
 
 
 def event(*args, **kwargs):
     def generate(f):
         e = Event(f, *args, **kwargs)
+        return e
+    return generate
+
+
+def event_factory(*args, **kwargs):
+    def generate(f):
+        e = EventFactory(f, *args, **kwargs)
         return e
     return generate

--- a/cavalcade/events.py
+++ b/cavalcade/events.py
@@ -52,7 +52,7 @@ class EventOutput:
         return self.event.raw_output
 
 
-class Event:
+class EventFactory:
     func = None
     f_args = None
     f_kwargs = None
@@ -61,7 +61,7 @@ class Event:
     c_kwargs = None
 
     manager = DefaultManager()
-    name = 'Event'
+    name = 'EventDecorator'
 
     def __init__(self, func: Callable, func_args: Union[Tuple, List] = (), func_kwargs: Dict = None,
                  callback: Callable = None, callback_args: Union[Tuple, List] = (), callback_kwargs: Dict = None,
@@ -77,6 +77,31 @@ class Event:
 
         self.manager = manager if manager else self.manager
         self.name = name if name else self.name
+
+    def __call__(self, *args, **kwargs):
+        kwargs.update(self.f_kwargs)
+        args = args + self.f_args
+
+        event = Event(func=self.func, func_args=self.f_args, func_kwargs=self.f_kwargs,
+                      callback=self.callback, callback_args=self.c_args, callback_kwargs=self.c_kwargs,
+                      manager=self.manager, name=self.name)
+
+        event.__call__(*args, **kwargs)
+
+        return event
+
+
+class Event(EventFactory):
+    output = None
+
+    def __init__(self, func: Callable, func_args: Union[Tuple, List] = (), func_kwargs: Dict = None,
+                 callback: Callable = None, callback_args: Union[Tuple, List] = (), callback_kwargs: Dict = None,
+                 manager: Manager = None, name: str = None):
+
+        super().__init__(func=func, func_args=func_args, func_kwargs=func_kwargs,
+                         callback=callback, callback_args=callback_args, callback_kwargs=callback_kwargs,
+                         manager=manager, name=name)
+
         self.output = EventOutput(self)
 
         self.raw_output = None

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="cavalcade",
-    version="1.0.0",
+    version="1.0.1",
     author="Thomas Wilmot",
     author_email="thomaswilmot@gmail.com",
     description="A lightweight, asynchronous event library for Python",


### PR DESCRIPTION
This is to improve the way functions/methods are decorated. In the previous version (1.0.0) when decorating via `cavalcade.event()`, when calling you would always get the same instance. This means you could get race conditions when you decorate a function and call it sequentially. Now when you decorate a function with the `cavalcade.event_factory()`, when you call it it returns a new instantiated `cavalcade.Event` object